### PR TITLE
Remove firefox skip

### DIFF
--- a/src/pages/cardDetails.ts
+++ b/src/pages/cardDetails.ts
@@ -51,7 +51,7 @@ export class CardDetails {
    * @returns
    */
   private getDescriptionWithText(descriptionText: string) {
-    return this.descriptionText.filter({ hasText: 'Text in the description field. Added by Playwright.' });
+    return this.descriptionText.filter({ hasText: descriptionText });
   }
 
   /**
@@ -63,7 +63,6 @@ export class CardDetails {
    * @param descriptionText Text to enter in description field
    */
   async fillDescriptionField(descriptionText: string) {
-    await this.descriptionInput.click();
     await this.descriptionInput.fill(descriptionText);
   }
 

--- a/src/pages/cardDetails.ts
+++ b/src/pages/cardDetails.ts
@@ -63,7 +63,8 @@ export class CardDetails {
    * @param descriptionText Text to enter in description field
    */
   async fillDescriptionField(descriptionText: string) {
-    await this.descriptionInput.fill(descriptionText);
+    await this.descriptionInput.click();
+    await this.descriptionInput.type(descriptionText);
   }
 
   /**

--- a/src/tests/cardWorkflow.spec.ts
+++ b/src/tests/cardWorkflow.spec.ts
@@ -18,8 +18,11 @@ test.beforeEach(async ({ kanbanBoard, browserName }) => {
   await kanbanBoard.assertCardExistsInList(startingListName, cardText);
 });
 
-test('Add details to card', async ({ kanbanBoard, cardDetails }) => {
+test('Add details to card', async ({ kanbanBoard, cardDetails, browserName }) => {
   console.log(`title of card ${cardText}`);
+  // Skip on Firefox
+  test.skip(browserName === "firefox", "The fill method isn't working in Firefox, need to investigate");
+
   // Add details to card
   await kanbanBoard.openCard(cardText);
 

--- a/src/tests/cardWorkflow.spec.ts
+++ b/src/tests/cardWorkflow.spec.ts
@@ -16,16 +16,14 @@ test.beforeEach(async ({ kanbanBoard, browserName }) => {
 
   // Assert card was created
   await kanbanBoard.assertCardExistsInList(startingListName, cardText);
+  console.log(`title of card ${cardText}`);
 });
 
 test('Add details to card', async ({ kanbanBoard, cardDetails, browserName }) => {
-  console.log(`title of card ${cardText}`);
-  // Skip on Firefox
-  test.skip(browserName === "firefox", "The fill method isn't working in Firefox, need to investigate");
-
-  // Add details to card
+  // Open card
   await kanbanBoard.openCard(cardText);
 
+  // Add a description to the card
   let textInDescriptionField = "Text in the description field. Added by Playwright.";
   await cardDetails.fillDescriptionField(textInDescriptionField);
   await cardDetails.clickSaveButton();
@@ -41,7 +39,6 @@ test('Add details to card', async ({ kanbanBoard, cardDetails, browserName }) =>
 });
 
 test(`Drag a card`, async ({ kanbanBoard }) => {
-  console.log(`title of card ${cardText}`);
   // Assert card is not in the "Done" column
   await kanbanBoard.assertCardDoesNotExistInList(destinationListName, cardText);
 


### PR DESCRIPTION
Add a workaround (click() then type() instead of fill()) because fill() doesn't work in Firefox for the description field. Also doing some cleanup in the spec file.